### PR TITLE
chore: restrict files included in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.2",
   "description": "A fast Node.js implementation of the latest MessagePack spec",
   "main": "lib/index.js",
+  "files": [
+    "lib/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/coinative/notepack.git"


### PR DESCRIPTION
Currently, the content of `benchmarks/` and `test/` directories is also published to npm.
